### PR TITLE
Fix variable name in README.md example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ to be initialized. This won't send the program into a spinlock when the
 scale is disconnected and will probably also account for hardware failures.
 ```
 // 4. Acquire reading without blocking
-if (scale.wait_ready_timeout(1000)) {
+if (loadcell.wait_ready_timeout(1000)) {
     long reading = loadcell.get_units(10);
     Serial.print("Weight: ");
     Serial.println(reading, 2);


### PR DESCRIPTION
In response to issue #10 this commit fixes the name of a variable "scale" into "loadcell" in the example for the  non-blocking mode which originally read: 

// 4. Acquire reading without blocking
if (scale.wait_ready_timeout(1000)) {...

Where it should say:

// 4. Acquire reading without blocking
if (loadcell.wait_ready_timeout(1000)) {...
for consistency with the definition at the start of the example

HX711 loadcell;